### PR TITLE
Use singleton to configure and access the Pixy

### DIFF
--- a/src/org/usfirst/frc/team1492/robot/CameraSettings.java
+++ b/src/org/usfirst/frc/team1492/robot/CameraSettings.java
@@ -1,0 +1,15 @@
+package org.usfirst.frc.team1492.robot;
+
+public enum CameraSettings {
+    ORANGE_LIGHT((short) 17, 250),      // Settings for orange light ring - cam_setECV(64017)
+    GREEN_COMPETITION((short) 1, 80),   // Settings for green light ring at AZPX 2017 - cam_setECV(20481)
+    GREEN_SHOP((short) 2, 150);         // Settings for green light ring in workshop - cam_setECV(38402)
+
+    final short gain;
+    final int compensation;
+
+    private CameraSettings(short gain, int compensation) {
+        this.gain = gain;
+        this.compensation = compensation;
+    }
+}

--- a/src/org/usfirst/frc/team1492/robot/PixyCamera.java
+++ b/src/org/usfirst/frc/team1492/robot/PixyCamera.java
@@ -97,8 +97,9 @@ public enum PixyCamera {
 
             targets.sort((Block o1, Block o2) -> Integer.compare(o1.getX(), o2.getX()));
 
+            System.out.println("[pixy-vision]");
             for (int i = 0; i < targets.size(); i++) {
-                System.out.print("[pixy-vision] target " + i + ", x is " + targets.get(i).getX() + " ");
+                System.out.format(" target %d, x is %d", i, targets.get(i).getX());
             }
             System.out.println("");
             return new Block[] {targets.get(0), targets.get(targets.size() - 1)};

--- a/src/org/usfirst/frc/team1492/robot/PixyCamera.java
+++ b/src/org/usfirst/frc/team1492/robot/PixyCamera.java
@@ -1,0 +1,82 @@
+package org.usfirst.frc.team1492.robot;
+
+import java.util.ArrayList;
+
+public class PixyCamera {
+
+    static {
+        System.loadLibrary("pixy_java");
+    }
+
+    private static boolean initialized = false;
+
+    enum CameraSettings {
+        ORANGE_LIGHT((short) 17, 250),      // Settings for orange light ring - cam_setECV(64017)
+        GREEN_COMPETITION((short) 1, 80),   // Settings for green light ring at AZPX 2017 - cam_setECV(20481)
+        GREEN_SHOP((short) 2, 150);         // Settings for green light ring in workshop - cam_setECV(38402)
+
+        final short gain;
+        final int compensation;
+
+        private CameraSettings(short gain, int compensation) {
+            this.gain = gain;
+            this.compensation = compensation;
+        }
+    }
+
+
+    public PixyCamera(CameraSettings cameraSettings) {
+        if (!initialized) {
+            if (pixy.pixy_init() != 0) {
+                System.err.println("Error initializing the pixy! #####");
+            }
+
+            pixy.pixy_cam_set_auto_exposure_compensation((short) 0);
+            pixy.pixy_cam_set_auto_white_balance((short) 0);
+
+            // cam_setWBV(0x884040)
+            pixy.pixy_cam_set_white_balance_value((short) 64, (short) 64, (short) 136);
+
+            setPixySettings(cameraSettings);
+            initialized = true;
+        } else {
+            System.err.println("Pixy already initialized.");
+        }
+    }
+
+    public void setPixySettings(CameraSettings cameraSettings) {
+        pixy.pixy_cam_set_exposure_compensation(cameraSettings.gain, cameraSettings.compensation);
+    }
+
+    public boolean blocksAreNew() {
+        return pixy.pixy_blocks_are_new() == 1;
+    }
+
+    public int getBlocks(int maxCount, BlockArray blocks) {
+        return pixy.pixy_get_blocks(maxCount, blocks);
+    }
+
+    public static Block[] pickBlocks(BlockArray blocks, int blockCount) {
+        if (blockCount < 2) {
+            return null;
+        } else if (blockCount == 2) {
+            return new Block[] {blocks.getitem(0), blocks.getitem(1)};
+        } else if (blockCount > 2) {
+            System.out.println("[pixy-vision] blocks over 2");
+
+            ArrayList<Block> targets = new ArrayList<>();
+            for (int i = 0; i < blockCount; i++) {
+                targets.add(blocks.getitem(i));
+            }
+
+            targets.sort((Block o1, Block o2) -> Integer.compare(o1.getX(), o2.getX()));
+
+            for (int i = 0; i < targets.size(); i++) {
+                System.out.print("[pixy-vision] target " + i + ", x is " + targets.get(i).getX() + " ");
+            }
+            System.out.println("");
+            return new Block[] {targets.get(0), targets.get(targets.size() - 1)};
+        }
+        return null;
+    }
+}

--- a/src/org/usfirst/frc/team1492/robot/Robot.java
+++ b/src/org/usfirst/frc/team1492/robot/Robot.java
@@ -3,7 +3,6 @@ package org.usfirst.frc.team1492.robot;
 import org.usfirst.frc.team1492.robot.Gamepad.Axis;
 import org.usfirst.frc.team1492.robot.Gamepad.Button;
 import org.usfirst.frc.team1492.robot.HumanLoadLight.LightMode;
-import org.usfirst.frc.team1492.robot.PixyCamera.CameraSettings;
 import org.usfirst.frc.team1492.robot.autonomous.CommandFactory;
 import org.usfirst.frc.team1492.robot.autonomous.Mission;
 import org.usfirst.frc.team1492.robot.autonomous.MissionSendable;
@@ -28,7 +27,7 @@ public class Robot extends IterativeRobot {
     EnhancedJoystick driverRight;
     Gamepad manipulator;
 
-    PixyCamera pixyCamera = new PixyCamera(CameraSettings.GREEN_SHOP);
+    PixyCamera pixyCamera;
 
     GearPiston gearPiston;
 
@@ -82,6 +81,9 @@ public class Robot extends IterativeRobot {
         humanLoadLight = new HumanLoadLight(0);
 
         CameraServer.getInstance().startAutomaticCapture();
+
+        pixyCamera = PixyCamera.INSTANCE;
+        pixyCamera.setPixySettings(CameraSettings.GREEN_SHOP);
 
         commandFactory = new CommandFactory(driveBase, gearPiston, doors, pixyCamera);
 

--- a/src/org/usfirst/frc/team1492/robot/Robot.java
+++ b/src/org/usfirst/frc/team1492/robot/Robot.java
@@ -3,6 +3,7 @@ package org.usfirst.frc.team1492.robot;
 import org.usfirst.frc.team1492.robot.Gamepad.Axis;
 import org.usfirst.frc.team1492.robot.Gamepad.Button;
 import org.usfirst.frc.team1492.robot.HumanLoadLight.LightMode;
+import org.usfirst.frc.team1492.robot.PixyCamera.CameraSettings;
 import org.usfirst.frc.team1492.robot.autonomous.CommandFactory;
 import org.usfirst.frc.team1492.robot.autonomous.Mission;
 import org.usfirst.frc.team1492.robot.autonomous.MissionSendable;
@@ -21,15 +22,13 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
  */
 public class Robot extends IterativeRobot {
 
-    static {
-        System.loadLibrary("pixy_java");
-    }
-
     DriveBase driveBase;
 
     EnhancedJoystick driverLeft;
     EnhancedJoystick driverRight;
     Gamepad manipulator;
+
+    PixyCamera pixyCamera = new PixyCamera(CameraSettings.GREEN_SHOP);
 
     GearPiston gearPiston;
 
@@ -84,7 +83,7 @@ public class Robot extends IterativeRobot {
 
         CameraServer.getInstance().startAutomaticCapture();
 
-        commandFactory = new CommandFactory(driveBase, gearPiston, doors);
+        commandFactory = new CommandFactory(driveBase, gearPiston, doors, pixyCamera);
 
         Mission testEncoderVision = new Mission("test encoder vision");
         testEncoderVision.add(commandFactory.alignWithVision(30));

--- a/src/org/usfirst/frc/team1492/robot/autonomous/CommandFactory.java
+++ b/src/org/usfirst/frc/team1492/robot/autonomous/CommandFactory.java
@@ -85,7 +85,7 @@ public class CommandFactory {
     }
 
     public Command turnToTarget(boolean testing) {
-        return new TurnToTargetVisionCommand(driveBase, testing);
+        return new TurnToTargetVisionCommand(driveBase, pixyCamera, testing);
     }
 
     public Command setGearPiston(boolean out) {

--- a/src/org/usfirst/frc/team1492/robot/autonomous/CommandFactory.java
+++ b/src/org/usfirst/frc/team1492/robot/autonomous/CommandFactory.java
@@ -3,6 +3,7 @@ package org.usfirst.frc.team1492.robot.autonomous;
 import org.usfirst.frc.team1492.robot.Doors;
 import org.usfirst.frc.team1492.robot.DriveBase;
 import org.usfirst.frc.team1492.robot.GearPiston;
+import org.usfirst.frc.team1492.robot.PixyCamera;
 import org.usfirst.frc.team1492.robot.autonomous.commands.AlignWithVisionCommand;
 import org.usfirst.frc.team1492.robot.autonomous.commands.DelayCommand;
 import org.usfirst.frc.team1492.robot.autonomous.commands.MoveStraightCommand;
@@ -17,11 +18,13 @@ public class CommandFactory {
     private DriveBase driveBase;
     private GearPiston gearPiston;
     private Doors doors;
+    private PixyCamera pixyCamera;
 
-    public CommandFactory(DriveBase driveBase, GearPiston gearPiston, Doors doors) {
+    public CommandFactory(DriveBase driveBase, GearPiston gearPiston, Doors doors, PixyCamera pixyCamera) {
         this.driveBase = driveBase;
         this.gearPiston = gearPiston;
         this.doors = doors;
+        this.pixyCamera = pixyCamera;
     }
 
     public Command moveStraight(double speed, double time) {
@@ -74,7 +77,7 @@ public class CommandFactory {
     }
 
     public Command alignWithVision(boolean testing, boolean encoderStop, double encoderStopDistance) {
-        return new AlignWithVisionCommand(driveBase, testing, encoderStop, encoderStopDistance);
+        return new AlignWithVisionCommand(driveBase, pixyCamera, testing, encoderStop, encoderStopDistance);
     }
 
     public Command turnToTarget() {

--- a/src/org/usfirst/frc/team1492/robot/autonomous/commands/TurnToTargetVisionCommand.java
+++ b/src/org/usfirst/frc/team1492/robot/autonomous/commands/TurnToTargetVisionCommand.java
@@ -3,6 +3,7 @@ package org.usfirst.frc.team1492.robot.autonomous.commands;
 import org.usfirst.frc.team1492.robot.Block;
 import org.usfirst.frc.team1492.robot.BlockArray;
 import org.usfirst.frc.team1492.robot.DriveBase;
+import org.usfirst.frc.team1492.robot.PixyCamera;
 import org.usfirst.frc.team1492.robot.pixy;
 import org.usfirst.frc.team1492.robot.autonomous.Command;
 
@@ -12,6 +13,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 public class TurnToTargetVisionCommand implements Command {
 
     private DriveBase driveBase;
+    private PixyCamera pixyCamera;
     private BlockArray blocks = new BlockArray(100);
     private boolean locked = false;
     private boolean aimed = false;
@@ -19,23 +21,12 @@ public class TurnToTargetVisionCommand implements Command {
     private Preferences preferences;
     private boolean testing;
 
-    public TurnToTargetVisionCommand(DriveBase driveBase, boolean testing) {
+    public TurnToTargetVisionCommand(DriveBase driveBase, PixyCamera pixyCamera, boolean testing) {
         this.testing = testing;
         this.driveBase = driveBase;
+        this.pixyCamera = pixyCamera;
 
         blocks = new BlockArray(100);
-        pixy.pixy_init();
-
-        pixy.pixy_cam_set_auto_exposure_compensation((short) 0);
-        pixy.pixy_cam_set_auto_white_balance((short) 0);
-
-        // cam_setECV(64017)
-//      pixy.pixy_cam_set_exposure_compensation((short) 17, (short) 250);
-      // cam_setECV(25601) for the bright light rings
-      pixy.pixy_cam_set_exposure_compensation((short) 1, (short) 100);
-
-        // cam_setWBV(0x884040)
-        pixy.pixy_cam_set_white_balance_value((short) 64, (short) 64, (short) 136);
 
         preferences = Preferences.getInstance();
         // preferences.putDouble("vision/gain", 0.7);
@@ -49,8 +40,8 @@ public class TurnToTargetVisionCommand implements Command {
 
     @Override
     public boolean run() {
-        if (pixy.pixy_blocks_are_new() == 1) {
-            int count = pixy.pixy_get_blocks(100, blocks);
+        if (pixyCamera.blocksAreNew()) {
+            int count = pixyCamera.getBlocks(100, blocks);
 
             SmartDashboard.putNumber("Number blocks", count);
 


### PR DESCRIPTION
This changes the access of the Pixy to be through the `PixyCamera` object. `PixyCamera` is a singleton because there is only one Pixy connected to the robot and the `pixy` class is completely static (it is derived from C code).

The configuration of the Pixy is also handled by the `PixyCamera` object; to configure the Pixy, a `CameraSettings` is passed to the `setPixySettings` method. `CameraSettings` is an enum with the different camera configurations we find useful. This makes it easier and better organized to calibrate the Pixy.

To handle disconnection of the Pixy, the `blocksAreNew` method checks if the Pixy is still connected. If the Pixy is disconnected, it closes the connection, waits 20 milliseconds, and reconnects to the Pixy. When the Pixy is disconnected, `blocksAreNew` returns false. If `BlocksAreNew` is called after 20 milliseconds have elapsed, it will reconnect to the Pixy. To ensure the Pixy is reconnected even if `blocksAreNew` is not called after 20 milliseconds, `blocksAreNew` creates a `TimerTask` to call itself in 20 milliseconds. This is to ensure the Pixy gets reconnected. (_This may not be thread safe, I am not sure._) The disconnection of the Pixy is detected by querying a parameter of the Pixy and checking for an error.

This needs to be tested on the robot before this can be merged. This should close #45 and #42.