### PR TITLE
Update code to be compatible with the 2018 WPILib API

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,9 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-  <classpathentry kind="src" path="src"/>
-  <classpathentry kind="var" path="wpilib" sourcepath="wpilib.sources"/>
-  <classpathentry kind="var" path="networktables" sourcepath="networktables.sources"/>
-  <classpathentry kind="var" path="opencv" sourcepath="opencv.sources"/>
-  <classpathentry kind="var" path="cscore" sourcepath="cscore.sources"/>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-  <classpathentry kind="output" path="bin"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="var" path="wpilib" sourcepath="wpilib.sources"/>
+	<classpathentry kind="var" path="networktables" sourcepath="networktables.sources"/>
+	<classpathentry kind="var" path="opencv" sourcepath="opencv.sources"/>
+	<classpathentry kind="var" path="cscore" sourcepath="cscore.sources"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="var" path="wpiutil" sourcepath="wpiutil.sources"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/src/org/usfirst/frc/team1492/robot/autonomous/MissionSendable.java
+++ b/src/org/usfirst/frc/team1492/robot/autonomous/MissionSendable.java
@@ -2,15 +2,11 @@ package org.usfirst.frc.team1492.robot.autonomous;
 
 import java.util.function.Supplier;
 
-import edu.wpi.first.wpilibj.NamedSendable;
-import edu.wpi.first.wpilibj.tables.ITable;
-import edu.wpi.first.wpilibj.tables.ITableListener;
+import edu.wpi.first.wpilibj.Sendable;
+import edu.wpi.first.wpilibj.SendableBase;
+import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
 
-public class MissionSendable implements NamedSendable {
-
-    private ITable table;
-    private String name;
-
+public class MissionSendable extends SendableBase implements Sendable {
     private Supplier<Mission> missionSupplier;
 
     private boolean running = false;
@@ -19,7 +15,7 @@ public class MissionSendable implements NamedSendable {
     private Mission selectedMission;
 
     public MissionSendable(String name, Supplier<Mission> selectedMissionSupplier) {
-        this.name = name;
+        setName(name);
         missionSupplier = selectedMissionSupplier;
     }
 
@@ -35,7 +31,6 @@ public class MissionSendable implements NamedSendable {
                     return running;
                 } else {
                     running = false;
-                    table.putBoolean("running", false);
                 }
             }
 
@@ -44,7 +39,6 @@ public class MissionSendable implements NamedSendable {
             if (finished) {
                 running = false;
                 initialized = false;
-                table.putBoolean("running", false);
                 System.out.format("Teleop mission '%s' Completed Successfully%n", selectedMission.getName());
             }
         } else if (!finished) {
@@ -57,39 +51,10 @@ public class MissionSendable implements NamedSendable {
     }
 
 
-    private final ITableListener listener = (table, key, value, isNew) -> {
-        running = (boolean) value;
-    };
-
     @Override
-    public void initTable(ITable subtable) {
-        if (table != null) {
-            table.removeTableListener(listener);
-        }
-
-        table = subtable;
-        if (table != null) {
-        table.putString("name", name);
-        table.putBoolean("running", false);
-        table.addTableListener("running", listener, false);
-        } else {
-            System.err.println("MissionSendable initTable passed null ITable!");
-        }
+    public void initSendable(SendableBuilder builder) {
+      builder.setSmartDashboardType("Command");
+      builder.addStringProperty(".name", this::getName, null);
+      builder.addBooleanProperty("running", ()->this.running, (value)->running=value);
     }
-
-    @Override
-    public ITable getTable() {
-        return table;
-    }
-
-    @Override
-    public String getSmartDashboardType() {
-        return "Command";
-    }
-
-    @Override
-    public String getName() {
-        return name;
-    }
-
 }


### PR DESCRIPTION
The WPILib API for NetworkTables changed from 2017 to 2018, affecting the MissionSendable class. This will update MissionSendable for the new API.

Additionally, the `.classpath` file changed. I think this was WPILib's doing and seems acceptable so I am committing it.