### PR TITLE
Add a drive only mode

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,9 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-  <classpathentry kind="src" path="src"/>
-  <classpathentry kind="var" path="wpilib" sourcepath="wpilib.sources"/>
-  <classpathentry kind="var" path="networktables" sourcepath="networktables.sources"/>
-  <classpathentry kind="var" path="opencv" sourcepath="opencv.sources"/>
-  <classpathentry kind="var" path="cscore" sourcepath="cscore.sources"/>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-  <classpathentry kind="output" path="bin"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="var" path="wpilib" sourcepath="wpilib.sources"/>
+	<classpathentry kind="var" path="networktables" sourcepath="networktables.sources"/>
+	<classpathentry kind="var" path="opencv" sourcepath="opencv.sources"/>
+	<classpathentry kind="var" path="cscore" sourcepath="cscore.sources"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="var" path="wpiutil" sourcepath="wpiutil.sources"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/src/org/usfirst/frc/team1492/robot/Robot.java
+++ b/src/org/usfirst/frc/team1492/robot/Robot.java
@@ -56,6 +56,7 @@ public class Robot extends IterativeRobot {
     boolean gearDeployRunning = false;
 
     final static String DRIVE_ONLY_MODE = "Drive Only Mode";
+    final static String TANK_DRIVE_MODE = "Tank drive mode";
 
     /**
      * This function is run when the robot is first started up and should be used for any
@@ -177,6 +178,9 @@ public class Robot extends IterativeRobot {
         if (!SmartDashboard.containsKey(DRIVE_ONLY_MODE)) {
             SmartDashboard.putBoolean(DRIVE_ONLY_MODE, false);
         }
+        if (!SmartDashboard.containsKey(TANK_DRIVE_MODE)) {
+            SmartDashboard.putBoolean(TANK_DRIVE_MODE, false);
+        }
     }
 
     /**
@@ -250,6 +254,11 @@ public class Robot extends IterativeRobot {
 
             double leftPower = (forwardCommand + turnCommand);
             double rightPower = (forwardCommand - turnCommand);
+
+            if (SmartDashboard.getBoolean(TANK_DRIVE_MODE, false)) {
+                leftPower = -driverLeft.getY();
+                rightPower = -driverRight.getY();
+            }
 
             leftPower = lowPowerLimiter(leftPower * 2.0 / 3.0);
             rightPower = lowPowerLimiter(rightPower * 2.0 / 3.0);

--- a/src/org/usfirst/frc/team1492/robot/Robot.java
+++ b/src/org/usfirst/frc/team1492/robot/Robot.java
@@ -55,6 +55,8 @@ public class Robot extends IterativeRobot {
     boolean gearDeployButtonPressed = false;
     boolean gearDeployRunning = false;
 
+    final static String DRIVE_ONLY_MODE = "Drive Only Mode";
+
     /**
      * This function is run when the robot is first started up and should be used for any
      * initialization code.
@@ -171,6 +173,10 @@ public class Robot extends IterativeRobot {
         SmartDashboard.putData("auto mission", missionChooser);
         missionSendable = new MissionSendable("Teleop Mission", () -> missionChooser.getSelected());
         SmartDashboard.putData(missionSendable);
+
+        if (!SmartDashboard.containsKey(DRIVE_ONLY_MODE)) {
+            SmartDashboard.putBoolean(DRIVE_ONLY_MODE, false);
+        }
     }
 
     /**
@@ -216,6 +222,10 @@ public class Robot extends IterativeRobot {
         driveBase.pidController.disable();
     }
 
+    public static double lowPowerLimiter(double power) {
+        return Math.max(Math.min(power, 2.0/3.0), -2.0/3.0);
+    }
+
     /**
      * This function is called periodically during operator control
      */
@@ -229,6 +239,22 @@ public class Robot extends IterativeRobot {
 
         if ((missionSendable.run() && !missionChooser.getSelected().enableControls)
                 || driveBase.pidController.isEnabled()) {
+            return;
+        }
+
+        if (SmartDashboard.getBoolean(DRIVE_ONLY_MODE, false)) {
+            driveBase.useHighGear(true);
+
+            double forwardCommand = -driverRight.getY() * 2.0/3.0;
+            double turnCommand = driverLeft.getX() * 2.0/3.0;
+
+            double leftPower = (forwardCommand + turnCommand);
+            double rightPower = (forwardCommand - turnCommand);
+
+            leftPower = lowPowerLimiter(leftPower * 2.0 / 3.0);
+            rightPower = lowPowerLimiter(rightPower * 2.0 / 3.0);
+
+            driveBase.drive(forwardCommand + turnCommand, forwardCommand - turnCommand);
             return;
         }
 

--- a/src/org/usfirst/frc/team1492/robot/autonomous/MissionSendable.java
+++ b/src/org/usfirst/frc/team1492/robot/autonomous/MissionSendable.java
@@ -2,15 +2,11 @@ package org.usfirst.frc.team1492.robot.autonomous;
 
 import java.util.function.Supplier;
 
-import edu.wpi.first.wpilibj.NamedSendable;
-import edu.wpi.first.wpilibj.tables.ITable;
-import edu.wpi.first.wpilibj.tables.ITableListener;
+import edu.wpi.first.wpilibj.Sendable;
+import edu.wpi.first.wpilibj.SendableBase;
+import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
 
-public class MissionSendable implements NamedSendable {
-
-    private ITable table;
-    private String name;
-
+public class MissionSendable extends SendableBase implements Sendable {
     private Supplier<Mission> missionSupplier;
 
     private boolean running = false;
@@ -19,7 +15,7 @@ public class MissionSendable implements NamedSendable {
     private Mission selectedMission;
 
     public MissionSendable(String name, Supplier<Mission> selectedMissionSupplier) {
-        this.name = name;
+        setName(name);
         missionSupplier = selectedMissionSupplier;
     }
 
@@ -35,7 +31,6 @@ public class MissionSendable implements NamedSendable {
                     return running;
                 } else {
                     running = false;
-                    table.putBoolean("running", false);
                 }
             }
 
@@ -44,7 +39,6 @@ public class MissionSendable implements NamedSendable {
             if (finished) {
                 running = false;
                 initialized = false;
-                table.putBoolean("running", false);
                 System.out.format("Teleop mission '%s' Completed Successfully%n", selectedMission.getName());
             }
         } else if (!finished) {
@@ -57,39 +51,10 @@ public class MissionSendable implements NamedSendable {
     }
 
 
-    private final ITableListener listener = (table, key, value, isNew) -> {
-        running = (boolean) value;
-    };
-
     @Override
-    public void initTable(ITable subtable) {
-        if (table != null) {
-            table.removeTableListener(listener);
-        }
-
-        table = subtable;
-        if (table != null) {
-        table.putString("name", name);
-        table.putBoolean("running", false);
-        table.addTableListener("running", listener, false);
-        } else {
-            System.err.println("MissionSendable initTable passed null ITable!");
-        }
+    public void initSendable(SendableBuilder builder) {
+      builder.setSmartDashboardType("Command");
+      builder.addStringProperty(".name", this::getName, null);
+      builder.addBooleanProperty("running", ()->this.running, (value)->running=value);
     }
-
-    @Override
-    public ITable getTable() {
-        return table;
-    }
-
-    @Override
-    public String getSmartDashboardType() {
-        return "Command";
-    }
-
-    @Override
-    public String getName() {
-        return name;
-    }
-
 }


### PR DESCRIPTION
This adds a drive only mode where the robot can only be driven around and none of its mechanisms  can be operated. It also adds an option to have the joysticks operate as tank drive when in the drive only mode.